### PR TITLE
Allow Joomla Naming Convention

### DIFF
--- a/site/ajax.php
+++ b/site/ajax.php
@@ -49,6 +49,14 @@ if ($input->get('module')) {
 
 		if (JFile::exists($helperFile)) {
 			require_once($helperFile);
+			if(!class_exists($class)){
+				$parts = explode('_', $module);
+				$class = 'Mod';
+				foreach($parts as $part){
+					$class .= ucfirst($part);
+				}
+				$class .= 'Helper';
+			}
 
 			if (method_exists($class, $method . 'Ajax')) {
 				$results = call_user_func($class . '::' . $method . 'Ajax');

--- a/site/ajax.php
+++ b/site/ajax.php
@@ -44,20 +44,22 @@ if ($input->get('module')) {
 		jimport('joomla.filesystem.file');
 		$helperFile = JPATH_BASE . '/modules/mod_' . $module . '/helper.php';
 
-		$class  = 'mod' . ucfirst($module) . 'Helper';
+		if (strpos($module, '_')) {
+			$parts = explode('_', $module);
+			$class = 'mod';
+			foreach ($parts as $part) {
+				$class .= ucfirst($part);
+			}
+			$class .= 'Helper';
+		} else {
+			$class = 'mod' . ucfirst($module) . 'Helper';
+		}
+		
 		$method = $input->get('method') ? $input->get('method') : 'get';
 
 		if (JFile::exists($helperFile)) {
 			require_once($helperFile);
-			if(!class_exists($class)){
-				$parts = explode('_', $module);
-				$class = 'Mod';
-				foreach($parts as $part){
-					$class .= ucfirst($part);
-				}
-				$class .= 'Helper';
-			}
-
+			
 			if (method_exists($class, $method . 'Ajax')) {
 				$results = call_user_func($class . '::' . $method . 'Ajax');
 			} else {


### PR DESCRIPTION
Allow Helper Classes to be named camel case, while module names are separated by an underscore.
