### PR TITLE
Use the equivalent of JResponseJson

### DIFF
--- a/ajax.xml
+++ b/ajax.xml
@@ -8,7 +8,7 @@
 	<authorUrl>http://betweenbrain.com</authorUrl>
 	<copyright>Copyright (C) 2013 betweenbrain llc. All rights reserved.</copyright>
 	<license>GNU General Public License version 2, or later.</license>
-	<version>2.5.2</version>
+	<version>3.0.0</version>
 	<description>A Joomla! 1.5/2.5 Ajax interface</description>
 
 	<files folder="site">

--- a/ajax.xml
+++ b/ajax.xml
@@ -13,6 +13,7 @@
 
 	<files folder="site">
 		<filename>ajax.php</filename>
+		<filename>response.php</filename>
 		<filename>index.html</filename>
 	</files>
 

--- a/site/ajax.php
+++ b/site/ajax.php
@@ -138,7 +138,6 @@ switch ($format)
 		// Set up the response
 		$response = new AjaxResponse($results);
 		echo (string) $response;
-		$app->close();
 		break;
 	case 'debug':
 		echo '<pre>' . print_r($results, true) . '</pre>';

--- a/site/ajax.php
+++ b/site/ajax.php
@@ -131,8 +131,13 @@ if (!is_null($error))
 switch ($format)
 {
 	case 'json':
+		// Require the backported JResponseJson class
+		require_once dirname(__FILE__) . '/response.php';
 		JResponse::setHeader('Content-Type', 'application/json', true);
-		echo json_encode($results);
+
+		// Set up the response
+		$response = new AjaxResponse($results);
+		echo (string) $response;
 		$app->close();
 		break;
 	case 'debug':

--- a/site/response.php
+++ b/site/response.php
@@ -18,7 +18,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  2.0
  */
-class JResponseJson
+class AjaxResponse
 {
 	/**
 	 * Determines whether the request was successful

--- a/site/response.php
+++ b/site/response.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * File       ajax.php
+ * Created    12/30/14 4:54 PM
+ * Author     Matt Thomas | matt@betweenbrain.com | http://betweenbrain.com
+ * Support    https://github.com/betweenbrain/Joomla-Ajax-Interface/issues
+ * Copyright  Copyright (C) 2013 betweenbrain llc. All Rights Reserved.
+ * License    GNU General Public License version 2, or later.
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * JSON Response class.
+ *
+ * This class serves to provide the Joomla Platform with a common interface to access
+ * response variables for e.g. Ajax requests.
+ *
+ * @since  2.0
+ */
+class JResponseJson
+{
+	/**
+	 * Determines whether the request was successful
+	 *
+	 * @var    boolean
+	 * @since  2.0
+	 */
+	public $success = true;
+
+	/**
+	 * The main response message
+	 *
+	 * @var    string
+	 * @since  2.0
+	 */
+	public $message = null;
+
+	/**
+	 * Array of messages gathered in the JApplication object
+	 *
+	 * @var    array
+	 * @since  2.0
+	 */
+	public $messages = null;
+
+	/**
+	 * The response data
+	 *
+	 * @var    mixed
+	 * @since  2.0
+	 */
+	public $data = null;
+
+	/**
+	 * Constructor
+	 *
+	 * @param   mixed    $response        The Response data
+	 * @param   string   $message         The main response message
+	 * @param   boolean  $error           True, if the success flag shall be set to false, defaults to false
+	 * @param   boolean  $ignoreMessages  True, if the message queue shouldn't be included, defaults to false
+	 *
+	 * @since   2.0
+	 */
+	public function __construct($response = null, $message = null, $error = false, $ignoreMessages = false)
+	{
+		$this->message = $message;
+
+		// Get the message queue if requested and available
+		$app = JFactory::getApplication();
+
+		if (!$ignoreMessages && !is_null($app) && is_callable(array($app, 'getMessageQueue')))
+		{
+			$messages = $app->getMessageQueue();
+
+			// Build the sorted messages list
+			if (is_array($messages) && count($messages))
+			{
+				foreach ($messages as $message)
+				{
+					if (isset($message['type']) && isset($message['message']))
+					{
+						$lists[$message['type']][] = $message['message'];
+					}
+				}
+			}
+
+			// If messages exist add them to the output
+			if (isset($lists) && is_array($lists))
+			{
+				$this->messages = $lists;
+			}
+		}
+
+		// Check if we are dealing with an error
+		if ($response instanceof Exception)
+		{
+			// Prepare the error response
+			$this->success	= false;
+			$this->message	= $response->getMessage();
+		}
+		else
+		{
+			// Prepare the response data
+			$this->success	= !$error;
+			$this->data			= $response;
+		}
+	}
+
+	/**
+	 * Magic toString method for sending the response in JSON format
+	 *
+	 * @return  string  The response in JSON format
+	 *
+	 * @since   2.0
+	 */
+	public function __toString()
+	{
+		return json_encode($this);
+	}
+}

--- a/site/response.php
+++ b/site/response.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * This class serves to provide the Joomla Platform with a common interface to access
  * response variables for e.g. Ajax requests.
  *
- * @since  2.0
+ * @since  3.0
  */
 class AjaxResponse
 {
@@ -24,7 +24,7 @@ class AjaxResponse
 	 * Determines whether the request was successful
 	 *
 	 * @var    boolean
-	 * @since  2.0
+	 * @since  3.0
 	 */
 	public $success = true;
 
@@ -32,7 +32,7 @@ class AjaxResponse
 	 * The main response message
 	 *
 	 * @var    string
-	 * @since  2.0
+	 * @since  3.0
 	 */
 	public $message = null;
 
@@ -40,7 +40,7 @@ class AjaxResponse
 	 * Array of messages gathered in the JApplication object
 	 *
 	 * @var    array
-	 * @since  2.0
+	 * @since  3.0
 	 */
 	public $messages = null;
 
@@ -48,7 +48,7 @@ class AjaxResponse
 	 * The response data
 	 *
 	 * @var    mixed
-	 * @since  2.0
+	 * @since  3.0
 	 */
 	public $data = null;
 
@@ -60,7 +60,7 @@ class AjaxResponse
 	 * @param   boolean  $error           True, if the success flag shall be set to false, defaults to false
 	 * @param   boolean  $ignoreMessages  True, if the message queue shouldn't be included, defaults to false
 	 *
-	 * @since   2.0
+	 * @since   3.0
 	 */
 	public function __construct($response = null, $message = null, $error = false, $ignoreMessages = false)
 	{
@@ -112,7 +112,7 @@ class AjaxResponse
 	 *
 	 * @return  string  The response in JSON format
 	 *
-	 * @since   2.0
+	 * @since   3.0
 	 */
 	public function __toString()
 	{


### PR DESCRIPTION
This PR introduces a backported JResponseJson class to produce the repsonse. Note this will require a major version bump as the json structure returned is different (and not b/c compatible) with that returned now.

This is compatible back to PHP 5.0 (so some Joomla 1.5 installs might be at risk) as Exception class didn't exist before then. Ditto with the constructor method. 

Note I need to test this before it gets merged. This is just a first pass at getting it implemented.
